### PR TITLE
Fix CodeQL #1118 #1119: explicit https protocol check for thumbnailUrl

### DIFF
--- a/frontend/src/features/publishing/UnifiedPublisher.js
+++ b/frontend/src/features/publishing/UnifiedPublisher.js
@@ -392,7 +392,7 @@ const PlatformPreview = ({
           <video
             key={effectivePreviewUrl} // Force reload on URL change
             src={sanitizeUrl(effectivePreviewUrl)}
-            poster={thumbnailUrl ? sanitizeUrl(thumbnailUrl) : undefined}
+            poster={thumbnailUrl && String(thumbnailUrl).startsWith("https://") ? thumbnailUrl : undefined}
             controls={showControls}
             playsInline
             loop
@@ -2239,7 +2239,7 @@ const UnifiedPublisher = ({ onUpload, initialFile }) => {
                       {thumbnailUrl && (
                         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                           <img
-                            src={sanitizeUrl(String(thumbnailUrl))}
+                            src={String(thumbnailUrl).startsWith("https://") ? thumbnailUrl : undefined}
                             alt="Thumbnail"
                             style={{ width: 120, height: 68, objectFit: "cover", borderRadius: 6, border: "2px solid #a78bfa" }}
                           />


### PR DESCRIPTION
Replaced sanitizeUrl() with explicit String().startsWith('https://') check that CodeQL's static analysis can verify as a security control.

<!-- Short PR template to ensure Legal sign-off for compliance-sensitive changes -->

## Summary

<!-- Describe the purpose of this PR -->

## Related Issue
- Links to compliance / policy matrix items: `docs/POLICY-MATRIX.md`

## What changed
- Brief bullet list of changes.

## Compliance Checklist (required for PR merge)
- [ ] Legal review: ping @legal-team and include `legal-signoff: yes/no` in PR description
- [ ] `docs/POLICY-MATRIX.md` updated if behavior changed
- [ ] `compliance_logs` are populated for all actions introduced
- [ ] Tests added for fraud heuristics / gating logic
- [ ] Feature flags for staged rollout where applicable

## Release notes
- Include any public-facing text for the change (disclosure language, billing changes, etc.)

## Rollout plan
- Feature flag name(s):
- Monitoring/alerting to add:

## Testing notes for QA
- How to verify the feature in staging


<!-- Legal / Product: add sign-off comment like `legal-signoff: yes -- <name> (<date>)` below -->
