### PR TITLE
Kill CodeQL taint flow: sanitize thumbnailUrl at component entry

### DIFF
--- a/frontend/src/features/publishing/UnifiedPublisher.js
+++ b/frontend/src/features/publishing/UnifiedPublisher.js
@@ -300,6 +300,11 @@ const PlatformPreview = ({
   platformId,
   creatorInfo,
 }) => {
+  // Sanitize thumbnailUrl at entry point to stop taint flow
+  const safeThumbUrl =
+    typeof thumbnailUrl === "string" && thumbnailUrl.startsWith("https://")
+      ? thumbnailUrl
+      : undefined;
   // Correctly resolve the file to preview: Platform specific > Global
   const fileToPreview = data.file || globalFile;
 
@@ -392,7 +397,7 @@ const PlatformPreview = ({
           <video
             key={effectivePreviewUrl} // Force reload on URL change
             src={sanitizeUrl(effectivePreviewUrl)}
-            poster={thumbnailUrl && String(thumbnailUrl).startsWith("https://") ? thumbnailUrl : undefined}
+            poster={safeThumbUrl}
             controls={showControls}
             playsInline
             loop
@@ -2239,7 +2244,7 @@ const UnifiedPublisher = ({ onUpload, initialFile }) => {
                       {thumbnailUrl && (
                         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
                           <img
-                            src={String(thumbnailUrl).startsWith("https://") ? thumbnailUrl : undefined}
+                            src={safeThumbUrl}
                             alt="Thumbnail"
                             style={{ width: 120, height: 68, objectFit: "cover", borderRadius: 6, border: "2px solid #a78bfa" }}
                           />


### PR DESCRIPTION
Create safeThumbUrl local variable with validated https check before any JSX. CodeQL can verify this as fully sanitized since the taint chain is broken at the variable assignment, not inside a JSX expression where static analysis can't track it.

<!-- Short PR template to ensure Legal sign-off for compliance-sensitive changes -->

## Summary

<!-- Describe the purpose of this PR -->

## Related Issue
- Links to compliance / policy matrix items: `docs/POLICY-MATRIX.md`

## What changed
- Brief bullet list of changes.

## Compliance Checklist (required for PR merge)
- [ ] Legal review: ping @legal-team and include `legal-signoff: yes/no` in PR description
- [ ] `docs/POLICY-MATRIX.md` updated if behavior changed
- [ ] `compliance_logs` are populated for all actions introduced
- [ ] Tests added for fraud heuristics / gating logic
- [ ] Feature flags for staged rollout where applicable

## Release notes
- Include any public-facing text for the change (disclosure language, billing changes, etc.)

## Rollout plan
- Feature flag name(s):
- Monitoring/alerting to add:

## Testing notes for QA
- How to verify the feature in staging


<!-- Legal / Product: add sign-off comment like `legal-signoff: yes -- <name> (<date>)` below -->
