### PR TITLE
Fix Viral Clip Studio export controls

### DIFF
--- a/frontend/src/components/ViralClipStudio.css
+++ b/frontend/src/components/ViralClipStudio.css
@@ -2231,6 +2231,49 @@
 
 .render-destination-row {
   margin-bottom: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 5px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 14px;
+  background: rgba(8, 15, 28, 0.72);
+}
+
+.render-destination-row button {
+  min-width: 0;
+  min-height: 38px;
+  padding: 8px 6px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.68);
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    color 0.16s ease,
+    background 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.render-destination-row button:hover:not(:disabled) {
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.render-destination-row button.is-active {
+  color: #fff;
+  border-color: rgba(129, 92, 246, 0.42);
+  background: linear-gradient(135deg, rgba(109, 40, 217, 0.34), rgba(14, 165, 233, 0.2));
+  box-shadow: 0 8px 18px rgba(76, 29, 149, 0.18);
+}
+
+.render-destination-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .editing-tools {
@@ -2511,22 +2554,6 @@
 .export-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 20px 40px rgba(251, 113, 133, 0.3);
-}
-
-.local-export-btn {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%) !important;
-  box-shadow: 0 16px 36px rgba(16, 185, 129, 0.24) !important;
-  font-size: 0.92rem !important;
-  min-height: 48px !important;
-}
-
-.local-export-btn:hover {
-  box-shadow: 0 20px 40px rgba(16, 185, 129, 0.3) !important;
-}
-
-.local-export-btn:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
 }
 
 .clips-scroller::-webkit-scrollbar,
@@ -4933,6 +4960,10 @@
 }
 
 @media (max-width: 760px) {
+  .render-destination-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .preview-mode-switch {
     width: 100%;
   }

--- a/frontend/src/components/ViralClipStudio.js
+++ b/frontend/src/components/ViralClipStudio.js
@@ -1352,10 +1352,7 @@ const ViralClipStudio = ({
   const [isExtractingAudio, setIsExtractingAudio] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [exportStatusLabel, setExportStatusLabel] = useState("Render Final Clip");
-  const [isLocalExporting, setIsLocalExporting] = useState(false);
-  const [localExportProgress, setLocalExportProgress] = useState(0);
-  const localRecorderRef = useRef(null);
-  const localChunksRef = useRef([]);
+  const [selectedExportDestination, setSelectedExportDestination] = useState("general");
   const loggedScannerEntryRef = useRef(new Set());
 
   const [timeline, setTimeline] = useState(() => {
@@ -4145,115 +4142,6 @@ const ViralClipStudio = ({
     } finally {
       setExportStatusLabel("Render Final Clip");
       setIsExporting(false);
-    }
-  };
-
-  // Client-side canvas export — no backend, no credits, instant local download
-  const handleLocalExport = () => {
-    const frame = phoneFrameRef.current;
-    if (!frame) {
-      toast.error("Preview frame not available. Try again.");
-      return;
-    }
-
-    const hasAiFeatures =
-      autoCaptions || smartCrop || silenceRemoval || removeWatermark || addHook || addMusic;
-    if (hasAiFeatures) {
-      const proceed = window.confirm(
-        "⚠️ AI features (captions, smart crop, silence removal, watermark removal, hook effects, music) " +
-          "will NOT be included in the local save. Only your visible overlays and current timeline will be captured.\n\n" +
-          'For full quality with AI features, use "Render Final Clip" instead.\n\nContinue with local save?'
-      );
-      if (!proceed) return;
-    }
-
-    if (typeof MediaRecorder === "undefined") {
-      toast.error("Your browser does not support local recording. Please use 'Render Final Clip'.");
-      return;
-    }
-
-    const mimeType =
-      ["video/webm;codecs=vp9,opus", "video/webm;codecs=vp8,opus", "video/webm"].find(mt =>
-        MediaRecorder.isTypeSupported(mt)
-      ) || "video/webm";
-
-    setIsLocalExporting(true);
-    setLocalExportProgress(0);
-    localChunksRef.current = [];
-
-    try {
-      const stream = frame.captureStream(30);
-      const recorder = new MediaRecorder(stream, {
-        mimeType,
-        videoBitsPerSecond: 6000000,
-        audioBitsPerSecond: 128000,
-      });
-
-      localRecorderRef.current = recorder;
-
-      recorder.ondataavailable = e => {
-        if (e.data.size > 0) localChunksRef.current.push(e.data);
-      };
-
-      recorder.onstop = () => {
-        const blob = new Blob(localChunksRef.current, { type: mimeType });
-        const ext = mimeType.includes("webm") ? "webm" : "mp4";
-        const safeName =
-          (selectedClip?.id || "viral-clip")
-            .replace(/[^a-zA-Z0-9._-]+/g, "-")
-            .replace(/-+/g, "-")
-            .replace(/^-|-$/g, "") || "viral-clip";
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.href = url;
-        link.download = `${safeName}.${ext}`;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        setTimeout(() => URL.revokeObjectURL(url), 3000);
-
-        setIsLocalExporting(false);
-        setLocalExportProgress(100);
-        toast.success(`Saved "${safeName}.${ext}" to your device!`);
-
-        // Stop all tracks
-        stream.getTracks().forEach(track => track.stop());
-      };
-
-      recorder.onerror = () => {
-        setIsLocalExporting(false);
-        toast.error("Local recording failed. Try 'Render Final Clip' instead.");
-      };
-
-      // Record until the current timeline window end, then auto-stop
-      const clipDuration = Math.max(
-        1,
-        Number(currentTimelineWindow.end || 0) - Number(currentTimelineWindow.start || 0)
-      );
-      recorder.start(500);
-
-      // Progress updates
-      const startTime = Date.now();
-      const progressInterval = setInterval(() => {
-        const elapsed = (Date.now() - startTime) / 1000;
-        const pct = Math.min(99, Math.round((elapsed / clipDuration) * 100));
-        setLocalExportProgress(pct);
-      }, 200);
-
-      // Auto-stop after clip duration
-      setTimeout(
-        () => {
-          clearInterval(progressInterval);
-          if (recorder.state === "recording") {
-            recorder.stop();
-          }
-        },
-        clipDuration * 1000 + 500
-      );
-    } catch (err) {
-      console.error("Local export failed:", err);
-      setIsLocalExporting(false);
-      toast.error("Local export failed: " + (err.message || "Unknown error"));
     }
   };
 
@@ -10023,46 +9911,36 @@ const ViralClipStudio = ({
               <p className="panel-description">
                 Final export uses the hook treatment and B-roll layers you approved in Studio.
               </p>
-              <div className="clip-guidance-actions render-destination-row">
-                <button
-                  type="button"
-                  className="clip-action-btn"
-                  onClick={() => void handleExportRender("tiktok")}
-                  disabled={isExporting}
-                >
-                  Export TikTok
-                </button>
-                <button
-                  type="button"
-                  className="clip-action-btn"
-                  onClick={() => void handleExportRender("reels")}
-                  disabled={isExporting}
-                >
-                  Export Reels
-                </button>
-                <button
-                  type="button"
-                  className="clip-action-btn"
-                  onClick={() => void handleExportRender("shorts")}
-                  disabled={isExporting}
-                >
-                  Export Shorts
-                </button>
+              <div
+                className="render-destination-row"
+                role="radiogroup"
+                aria-label="Export destination"
+              >
+                {[
+                  { value: "general", label: "Download" },
+                  { value: "tiktok", label: "TikTok" },
+                  { value: "reels", label: "Reels" },
+                  { value: "shorts", label: "Shorts" },
+                ].map(destination => (
+                  <button
+                    key={destination.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={selectedExportDestination === destination.value}
+                    className={selectedExportDestination === destination.value ? "is-active" : ""}
+                    onClick={() => setSelectedExportDestination(destination.value)}
+                    disabled={isExporting}
+                  >
+                    {destination.label}
+                  </button>
+                ))}
               </div>
               <button
                 className="export-btn"
-                onClick={() => void handleExportRender("general")}
-                disabled={isExporting || isLocalExporting}
+                onClick={() => void handleExportRender(selectedExportDestination)}
+                disabled={isExporting}
               >
                 {exportStatusLabel}
-              </button>
-              <button
-                className="export-btn local-export-btn"
-                onClick={handleLocalExport}
-                disabled={isExporting || isLocalExporting}
-                title="Capture the preview frame directly — no credits, no backend rendering. Overlays and timeline only."
-              >
-                {isLocalExporting ? `Saving... ${localExportProgress}%` : "💾 Save Locally (Free)"}
               </button>
               {isExporting && (
                 <button
@@ -10090,9 +9968,7 @@ const ViralClipStudio = ({
                   textAlign: "center",
                 }}
               >
-                {isLocalExporting
-                  ? "Recording your preview frame to a file..."
-                  : "Save Locally captures exactly what you see in the hook and B-roll preview."}
+                One render includes your hook, B-roll, audio rules, captions, and selected destination.
               </p>
             </section>
 

--- a/frontend/src/components/__tests__/ViralClipStudio.test.js
+++ b/frontend/src/components/__tests__/ViralClipStudio.test.js
@@ -1183,8 +1183,9 @@ describe("ViralClipStudio timeline sequencing", () => {
 
     expect(screen.getByLabelText(/^Add Hook$/i)).toBeChecked();
 
+    fireEvent.click(screen.getByRole("radio", { name: "TikTok" }));
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /Export TikTok/i }));
+      fireEvent.click(screen.getByRole("button", { name: /Render Final Clip/i }));
     });
 
     await waitFor(() => {
@@ -1303,5 +1304,40 @@ describe("ViralClipStudio timeline sequencing", () => {
       expect(within(inspector).getByText("warm-bed")).toBeInTheDocument();
       expect(within(inspector).getByText("Duck under speech")).toBeInTheDocument();
     });
+  });
+
+  test("uses one reliable render action for the selected export destination", async () => {
+    const onSave = jest.fn(() => Promise.resolve());
+    render(
+      <ViralClipStudio
+        videoUrl="https://example.com/source.mp4"
+        clips={[{ id: "clip-1", start: 0, end: 20, duration: 20, reason: "Podcast hook" }]}
+        onSave={onSave}
+        onCancel={jest.fn()}
+        onStatusChange={jest.fn()}
+        currentMusic={null}
+        onMusicChange={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /Save Locally/i })).not.toBeInTheDocument();
+    const destinationPicker = screen.getByRole("radiogroup", { name: "Export destination" });
+    expect(within(destinationPicker).getByRole("radio", { name: "Download" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+
+    fireEvent.click(within(destinationPicker).getByRole("radio", { name: "TikTok" }));
+    expect(within(destinationPicker).getByRole("radio", { name: "TikTok" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Render Final Clip/i }));
+    });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onSave.mock.calls[0][2].exportDestination).toBe("tiktok");
   });
 });


### PR DESCRIPTION
## What changed
- removed the broken browser-only `Save Locally` recorder
- replaced four competing export actions with compact destination choices and one `Render Final Clip` action
- kept the existing full render pipeline so hooks, B-roll, captions, and audio rules are included
- added responsive styling and export-destination regression coverage

## Root cause
The local recorder called `captureStream()` on the preview `<div>`. Browsers do not support recording a generic DOM element this way, so the control could not create the promised edited clip.

## Impact
Users now choose Download, TikTok, Reels, or Shorts, then use one reliable render action. No backend files were changed.

## Validation
- 26 focused Viral Clip Studio tests passed
- production frontend build compiled successfully