### PR TITLE
Upgrade AutoPromote creative studio workflows

### DIFF
--- a/frontend/src/components/MultiCamCombiner.css
+++ b/frontend/src/components/MultiCamCombiner.css
@@ -1176,7 +1176,7 @@
 
 .nle-studio-hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
   gap: 18px;
   align-items: stretch;
   min-height: 0;
@@ -1227,6 +1227,328 @@
   min-height: clamp(280px, 38vh, 500px);
   border-radius: 18px;
   overflow: hidden;
+}
+
+.nle-proof-experience {
+  grid-template-rows: auto auto minmax(320px, 1fr) auto auto auto auto !important;
+  gap: 14px !important;
+  overflow: visible;
+  border-color: rgba(139, 92, 246, 0.32) !important;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(124, 58, 237, 0.18), transparent 32%),
+    radial-gradient(circle at 90% 8%, rgba(6, 182, 212, 0.12), transparent 30%),
+    linear-gradient(180deg, rgba(8, 12, 24, 0.98), rgba(3, 6, 15, 0.99)) !important;
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.32),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.025);
+}
+
+.nle-proof-heading {
+  display: grid;
+  gap: 4px;
+}
+
+.nle-proof-heading small {
+  color: rgba(226, 232, 240, 0.62);
+  font-size: 0.76rem;
+}
+
+.nle-proof-heading-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.nle-proof-fullscreen-btn {
+  min-height: 32px;
+  padding: 6px 11px;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 92, 246, 0.42);
+  background: rgba(88, 28, 135, 0.24);
+  color: #ede9fe;
+  font-size: 0.76rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.nle-proof-fullscreen-btn:hover {
+  border-color: rgba(167, 139, 250, 0.8);
+  background: rgba(109, 40, 217, 0.34);
+}
+
+.nle-proof-mode-switcher {
+  width: min(420px, 100%);
+  justify-self: center;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
+  padding: 4px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.82);
+}
+
+.nle-proof-mode-switcher button {
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.66);
+  font-size: 0.78rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.nle-proof-mode-switcher button.is-active {
+  background: linear-gradient(135deg, #6d28d9, #7c3aed 54%, #4f46e5);
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(124, 58, 237, 0.36);
+}
+
+.nle-proof-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: 16px;
+  background: radial-gradient(circle at center, rgba(30, 41, 59, 0.5), transparent 65%), #000;
+  isolation: isolate;
+}
+
+.nle-proof-directed-layer {
+  z-index: 1;
+}
+
+.nle-proof-raw-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  overflow: hidden;
+  border-radius: inherit;
+  background: #000;
+  will-change: clip-path;
+}
+
+.nle-proof-raw-layer video,
+.nle-proof-raw-layer img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nle-proof-label {
+  position: absolute;
+  z-index: 5;
+  top: 14px;
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(2, 6, 23, 0.74);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  backdrop-filter: blur(12px);
+  pointer-events: none;
+}
+
+.nle-proof-label.is-raw {
+  left: 14px;
+}
+
+.nle-proof-label.is-directed {
+  right: 14px;
+  border-color: rgba(167, 139, 250, 0.46);
+  color: #ede9fe;
+}
+
+.nle-proof-reveal-input {
+  position: absolute;
+  inset: 0;
+  z-index: 7;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: ew-resize;
+}
+
+.nle-proof-divider {
+  position: absolute;
+  z-index: 6;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-1px);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 0 22px rgba(167, 139, 250, 0.72);
+  pointer-events: none;
+}
+
+.nle-proof-divider span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  transform: translate(-50%, -50%);
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.94);
+  background: linear-gradient(135deg, #6d28d9, #4f46e5);
+  color: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.42);
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.nle-proof-moments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.nle-proof-moments > button {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.7);
+  color: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nle-proof-moments > button:hover,
+.nle-proof-moments > button.is-current {
+  border-color: rgba(139, 92, 246, 0.62);
+  background: rgba(76, 29, 149, 0.24);
+}
+
+.nle-proof-moment-visual {
+  width: 52px;
+  aspect-ratio: 16 / 10;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-radius: 9px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.68), rgba(8, 145, 178, 0.5)), #111827;
+}
+
+.nle-proof-moment-visual.is-moment-2 {
+  background: linear-gradient(135deg, rgba(8, 145, 178, 0.62), rgba(14, 116, 144, 0.25));
+}
+
+.nle-proof-moment-visual.is-moment-3 {
+  background: linear-gradient(135deg, rgba(219, 39, 119, 0.55), rgba(109, 40, 217, 0.5));
+}
+
+.nle-proof-moment-visual em {
+  width: 23px;
+  height: 23px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.64);
+  color: #fff;
+  font-style: normal;
+  font-size: 0.68rem;
+  font-weight: 900;
+}
+
+.nle-proof-moment-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.nle-proof-moment-copy strong,
+.nle-proof-moment-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nle-proof-moment-copy strong {
+  color: #f8fafc;
+  font-size: 0.76rem;
+}
+
+.nle-proof-moment-copy small,
+.nle-proof-moments time {
+  color: rgba(203, 213, 225, 0.62);
+  font-size: 0.66rem;
+}
+
+.nle-proof-moments time {
+  font-variant-numeric: tabular-nums;
+}
+
+.nle-proof-receipt {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(34, 197, 94, 0.18);
+  background:
+    linear-gradient(90deg, rgba(6, 78, 59, 0.16), rgba(30, 41, 59, 0.44)), rgba(2, 6, 23, 0.72);
+}
+
+.nle-proof-receipt > div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(226, 232, 240, 0.84);
+}
+
+.nle-proof-receipt span {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border-radius: 8px;
+  background: rgba(16, 185, 129, 0.13);
+  color: #6ee7b7;
+  font-size: 0.68rem;
+  font-weight: 900;
+}
+
+.nle-proof-receipt strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.7rem;
+}
+
+.nle-proof-experience.is-fullscreen {
+  position: fixed;
+  z-index: 10000;
+  inset: 16px;
+  width: auto;
+  max-width: none;
+  max-height: calc(100dvh - 32px);
+  overflow: auto;
+  grid-template-rows: auto auto minmax(58dvh, 1fr) auto auto auto auto !important;
+  border-radius: 24px;
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.84);
 }
 
 .nle-studio-preview-pill {
@@ -1361,6 +1683,84 @@
   box-shadow:
     0 24px 70px rgba(0, 0, 0, 0.34),
     inset 0 0 0 1px rgba(245, 158, 11, 0.08);
+}
+
+.nle-proof-render-card {
+  align-self: start;
+  padding: 10px;
+  gap: 0;
+  border-color: rgba(139, 92, 246, 0.3);
+  background:
+    radial-gradient(circle at 30% 0%, rgba(124, 58, 237, 0.14), transparent 38%),
+    linear-gradient(180deg, rgba(10, 15, 27, 0.98), rgba(3, 7, 16, 0.98));
+}
+
+.nle-proof-render-summary {
+  width: 100%;
+  min-height: 72px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.66);
+  color: #fff;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nle-proof-render-summary > span {
+  display: grid;
+  gap: 4px;
+}
+
+.nle-proof-render-summary small {
+  color: #c4b5fd;
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.nle-proof-render-summary strong {
+  color: #f8fafc;
+  font-size: 0.84rem;
+}
+
+.nle-proof-render-summary em {
+  flex: 0 0 auto;
+  color: #a78bfa;
+  font-size: 0.7rem;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.nle-proof-render-details {
+  display: none;
+  gap: 16px;
+  padding: 16px 10px 10px;
+}
+
+.nle-proof-render-card.is-open .nle-proof-render-details {
+  display: grid;
+}
+
+.nle-proof-render-details > .nle-eyebrow {
+  color: #fbbf24;
+}
+
+.nle-proof-render-details > strong {
+  justify-self: center;
+  min-width: 116px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(245, 158, 11, 0.38);
+  background: rgba(245, 158, 11, 0.1);
+  color: #facc15;
+  text-align: center;
+  font-size: 1.5rem;
 }
 
 .nle-render-ready-card > .nle-eyebrow {
@@ -3900,6 +4300,18 @@
     grid-template-columns: 1fr;
   }
 
+  .nle-studio-hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nle-proof-render-card {
+    width: 100%;
+  }
+
+  .nle-proof-receipt {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .nle-studio-topbar,
   .nle-studio-commerce-strip,
   .nle-studio-monitor-grid,
@@ -4021,6 +4433,35 @@
   .nle-studio-monitor-grid,
   .nle-live-switch-deck.is-studio-deck {
     grid-template-columns: 1fr;
+  }
+
+  .nle-proof-experience {
+    grid-template-rows: auto auto minmax(220px, 46dvh) auto auto auto auto !important;
+    padding: 10px !important;
+  }
+
+  .nle-proof-experience.is-fullscreen {
+    inset: 0;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .nle-proof-heading-actions,
+  .nle-studio-monitor-head {
+    align-items: flex-start;
+  }
+
+  .nle-proof-moments,
+  .nle-proof-receipt {
+    grid-template-columns: 1fr;
+  }
+
+  .nle-proof-moment-copy small {
+    white-space: normal;
+  }
+
+  .nle-proof-render-summary {
+    align-items: flex-start;
   }
 
   .nle-shell,

--- a/frontend/src/components/MultiCamCombiner.js
+++ b/frontend/src/components/MultiCamCombiner.js
@@ -170,6 +170,69 @@ export const getProductionProofRenderWindow = (durationSeconds, preferredStartSe
   };
 };
 
+export const buildCamCombinerProofMoments = (switches = [], durationSeconds = 0) => {
+  const duration = Math.max(0, Number(durationSeconds) || 0);
+  if (!duration) return [];
+  const safeSwitches = Array.isArray(switches)
+    ? switches
+        .map(item => ({ ...item, startTime: Math.max(0, Number(item?.startTime) || 0) }))
+        .sort((a, b) => a.startTime - b.startTime)
+    : [];
+  const pickTime = (preferredIndex, fallbackRatio) => {
+    const switchTime = safeSwitches[preferredIndex]?.startTime;
+    return Math.min(
+      duration,
+      Math.max(0, Number.isFinite(switchTime) ? switchTime : duration * fallbackRatio)
+    );
+  };
+  const middleIndex = Math.max(1, Math.floor(safeSwitches.length / 2));
+  const finalIndex = Math.max(1, safeSwitches.length - 1);
+  return [
+    {
+      id: "speaker-cut",
+      label: "Speaker cut",
+      caption: "Active speaker takes the frame",
+      time: pickTime(1, 0.24),
+    },
+    {
+      id: "reaction-caught",
+      label: "Reaction caught",
+      caption: "The listener stays in the moment",
+      time: pickTime(middleIndex, 0.52),
+    },
+    {
+      id: "shared-moment",
+      label: "Shared moment",
+      caption: "Both sides of the story stay visible",
+      time: pickTime(finalIndex, 0.76),
+    },
+  ];
+};
+
+export const getCamCombinerProofReceipt = ({
+  switches = [],
+  reactionOverlayEnabled = false,
+  hasExternalCleanAudio = false,
+  syncTone = "warning",
+} = {}) => [
+  {
+    id: "cuts",
+    value: `${Math.max(0, Array.isArray(switches) ? switches.length : 0)} camera cuts`,
+  },
+  {
+    id: "reactions",
+    value: reactionOverlayEnabled ? "Smart reactions" : "Reactions off",
+  },
+  {
+    id: "audio",
+    value: hasExternalCleanAudio ? "Clean audio" : "Camera audio",
+  },
+  {
+    id: "sync",
+    value: syncTone === "good" ? "Sync locked" : "Sync pending",
+  },
+];
+
 export const getRenderOutputUrl = render =>
   render?.output_url ||
   render?.outputUrl ||
@@ -2110,6 +2173,10 @@ function MultiCamCombiner({
   );
   const [autoDirectorSummary, setAutoDirectorSummary] = useState(null);
   const [studioMode, setStudioMode] = useState("combine");
+  const [proofMode, setProofMode] = useState("compare");
+  const [proofReveal, setProofReveal] = useState(50);
+  const [proofFullscreen, setProofFullscreen] = useState(false);
+  const [renderPanelOpen, setRenderPanelOpen] = useState(false);
   const [flowEditStyleId, setFlowEditStyleId] = useState(FLOW_EDIT_STYLE_PRESETS[1].id);
   const [flowImageStoryTemplateId, setFlowImageStoryTemplateId] = useState(
     IMAGE_STORY_TEMPLATE_PRESETS[0].id
@@ -2509,6 +2576,7 @@ function MultiCamCombiner({
   const scrollContainerRef = useRef(null);
   const previewPanelRef = useRef(null);
   const previewStageRef = useRef(null);
+  const rawProofVideoRef = useRef(null);
   const autoDirectorSignatureRef = useRef("");
   const audioAnalysisCacheRef = useRef(new Map());
   const previewVideoRefs = useRef({});
@@ -2582,6 +2650,8 @@ function MultiCamCombiner({
     () => sources.filter(source => Boolean(getSourceMediaUrl(source))),
     [sources]
   );
+  const programPreviewSources = readySources.length ? readySources : loadedVisualSources;
+  const rawProofSource = programPreviewSources[0] || null;
   const multicamDraftKey = useMemo(() => buildMulticamDraftKey(sources), [sources]);
   const flowFrameQualityByCameraId = useMemo(
     () =>
@@ -2694,6 +2764,10 @@ function MultiCamCombiner({
         timelineDuration || 0
       ),
     [readySources, sources, switches, timelineDuration]
+  );
+  const proofMoments = useMemo(
+    () => buildCamCombinerProofMoments(normalizedSwitches, timelineDuration),
+    [normalizedSwitches, timelineDuration]
   );
   const activeFlowSegments = useMemo(
     () =>
@@ -4337,6 +4411,37 @@ function MultiCamCombiner({
     externalAudioMixMode,
     externalAudioSourceProxy,
   ]);
+
+  useEffect(() => {
+    if (!rawProofSource || !isVideoSource(rawProofSource)) return;
+    const mappedTime = getSourceTimelineTime(
+      rawProofSource,
+      playhead,
+      timelineBounds.timelineStart
+    );
+    const isInRange = isSourceAvailableAtTime(rawProofSource, mappedTime);
+    syncMediaElement(rawProofVideoRef.current, mappedTime, isPlaying && isInRange, {
+      muted: true,
+      volume: 0,
+      playbackRate: 1,
+      driftThreshold: hasExternalCleanAudio ? 0.28 : DRIFT_THRESHOLD_SECONDS,
+      softDriftThreshold: 0.04,
+    });
+  }, [rawProofSource, playhead, isPlaying, timelineBounds.timelineStart, hasExternalCleanAudio]);
+
+  useEffect(() => {
+    if (!proofFullscreen) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = event => {
+      if (event.key === "Escape") setProofFullscreen(false);
+    };
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [proofFullscreen]);
 
   useEffect(() => {
     return () => {
@@ -6784,6 +6889,16 @@ function MultiCamCombiner({
     cleanAudioSyncJob,
     shouldUseBackendCleanAudioSync,
   ]);
+  const proofReceipt = useMemo(
+    () =>
+      getCamCombinerProofReceipt({
+        switches: normalizedSwitches,
+        reactionOverlayEnabled,
+        hasExternalCleanAudio,
+        syncTone: previewSyncState.tone,
+      }),
+    [normalizedSwitches, reactionOverlayEnabled, hasExternalCleanAudio, previewSyncState.tone]
+  );
 
   const ensureProgramOutputCleanAudioSync = async () => {
     if (!hasExternalCleanAudio) return true;
@@ -9295,27 +9410,81 @@ function MultiCamCombiner({
               </div>
 
               <div className="nle-studio-hero-grid">
-                <article className="nle-studio-program-card is-hero">
+                <article
+                  className={`nle-studio-program-card is-hero nle-proof-experience ${proofFullscreen ? "is-fullscreen" : ""}`}
+                >
                   <div className="nle-studio-monitor-head">
-                    <span className="nle-studio-monitor-label">Program Output</span>
-                    <span className="nle-studio-preview-pill">Preview only</span>
+                    <div className="nle-proof-heading">
+                      <span className="nle-studio-monitor-label">Proof Mode</span>
+                      <small>See what AutoPromote changed at the exact same moment.</small>
+                    </div>
+                    <div className="nle-proof-heading-actions">
+                      <span className="nle-studio-preview-pill">No credits used</span>
+                      <button
+                        type="button"
+                        className="nle-proof-fullscreen-btn"
+                        onClick={() => setProofFullscreen(current => !current)}
+                      >
+                        {proofFullscreen ? "Exit proof" : "Full-screen proof"}
+                      </button>
+                    </div>
+                  </div>
+                  <div className="nle-proof-mode-switcher" aria-label="Proof preview mode">
+                    {[
+                      { id: "raw", label: "Raw" },
+                      { id: "directed", label: "Auto Directed" },
+                      { id: "compare", label: "Compare" },
+                    ].map(option => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        className={proofMode === option.id ? "is-active" : ""}
+                        onClick={() => setProofMode(option.id)}
+                        aria-pressed={proofMode === option.id}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
                   </div>
                   <div className="nle-preview-shell nle-studio-program-shell">
-                    <div
-                      ref={previewStageRef}
-                      className={`nle-preview-stage is-layout-${previewMulticamLayoutMode} is-reaction-${previewReactionSide} ${focusPickerActive ? "is-focus-picking" : ""} ${previewStageMoodClass}`}
-                      style={studioProgramStageStyle}
-                    >
-                      {readySources.map(source => {
-                        const previewClassName = `nle-preview-video ${source.id === activeCameraId ? "is-active" : ""} ${
-                          source.id === previewSecondaryCameraId ||
-                          previewReactionCameraIds.includes(source.id)
-                            ? "is-secondary"
-                            : ""
-                        }`;
-                        if (isImageSource(source)) {
+                    <div className="nle-proof-stage" style={studioProgramStageStyle}>
+                      <div
+                        ref={previewStageRef}
+                        className={`nle-preview-stage nle-proof-directed-layer is-layout-${previewMulticamLayoutMode} is-reaction-${previewReactionSide} ${focusPickerActive ? "is-focus-picking" : ""} ${previewStageMoodClass}`}
+                        style={{
+                          position: "absolute",
+                          inset: 0,
+                          width: "100%",
+                          height: "100%",
+                          maxWidth: "none",
+                        }}
+                      >
+                        {programPreviewSources.map(source => {
+                          const previewClassName = `nle-preview-video ${source.id === activeCameraId ? "is-active" : ""} ${
+                            source.id === previewSecondaryCameraId ||
+                            previewReactionCameraIds.includes(source.id)
+                              ? "is-secondary"
+                              : ""
+                          }`;
+                          if (isImageSource(source)) {
+                            return (
+                              <img
+                                key={`preview-${source.id}`}
+                                ref={node => {
+                                  previewVideoRefs.current[source.id] = node;
+                                  if (node) {
+                                    applySafeMediaSource(node, getSourceMediaUrl(source));
+                                  }
+                                }}
+                                className={previewClassName}
+                                alt={source.label || source.name || "Story visual"}
+                                draggable="false"
+                                style={previewVideoStylesByCameraId[source.id]}
+                              />
+                            );
+                          }
                           return (
-                            <img
+                            <video
                               key={`preview-${source.id}`}
                               ref={node => {
                                 previewVideoRefs.current[source.id] = node;
@@ -9324,37 +9493,87 @@ function MultiCamCombiner({
                                 }
                               }}
                               className={previewClassName}
-                              alt={source.label || source.name || "Story visual"}
-                              draggable="false"
+                              playsInline
+                              muted
+                              preload="metadata"
                               style={previewVideoStylesByCameraId[source.id]}
                             />
                           );
-                        }
-                        return (
-                          <video
-                            key={`preview-${source.id}`}
-                            ref={node => {
-                              previewVideoRefs.current[source.id] = node;
-                              if (node) {
-                                applySafeMediaSource(node, getSourceMediaUrl(source));
-                              }
-                            }}
-                            className={previewClassName}
-                            playsInline
-                            muted
-                            style={previewVideoStylesByCameraId[source.id]}
-                          />
-                        );
-                      })}
-                      {!readySources.length ? (
-                        <div className="nle-empty-state">
-                          <strong>Load your first visual to start.</strong>
-                          <span>Program Output appears here once cameras are ready.</span>
+                        })}
+                        {!programPreviewSources.length ? (
+                          <div className="nle-empty-state">
+                            <strong>Your transformation will play here.</strong>
+                            <span>
+                              Add a camera to compare the raw recording with Auto Director.
+                            </span>
+                          </div>
+                        ) : null}
+                        {!isSingleSourceWorkflow &&
+                          previewMulticamLayoutMode === "split-vertical" &&
+                          previewSecondaryCamera && <div className="nle-preview-split-divider" />}
+                      </div>
+                      {rawProofSource && proofMode !== "directed" ? (
+                        <div
+                          className="nle-proof-raw-layer"
+                          style={{
+                            clipPath:
+                              proofMode === "compare"
+                                ? `inset(0 ${100 - proofReveal}% 0 0)`
+                                : "inset(0 0 0 0)",
+                          }}
+                        >
+                          {isImageSource(rawProofSource) ? (
+                            <img
+                              src={getSourceMediaUrl(rawProofSource)}
+                              alt={rawProofSource.label || "Raw camera"}
+                              draggable="false"
+                            />
+                          ) : (
+                            <video
+                              ref={node => {
+                                rawProofVideoRef.current = node;
+                                if (node) {
+                                  applySafeMediaSource(node, getSourceMediaUrl(rawProofSource));
+                                }
+                              }}
+                              playsInline
+                              muted
+                              preload="metadata"
+                            />
+                          )}
                         </div>
                       ) : null}
-                      {!isSingleSourceWorkflow &&
-                        previewMulticamLayoutMode === "split-vertical" &&
-                        previewSecondaryCamera && <div className="nle-preview-split-divider" />}
+                      {rawProofSource ? (
+                        <>
+                          {proofMode !== "directed" ? (
+                            <span className="nle-proof-label is-raw">Raw camera</span>
+                          ) : null}
+                          {proofMode !== "raw" ? (
+                            <span className="nle-proof-label is-directed">Auto directed</span>
+                          ) : null}
+                        </>
+                      ) : null}
+                      {proofMode === "compare" && rawProofSource ? (
+                        <>
+                          <input
+                            className="nle-proof-reveal-input"
+                            type="range"
+                            min="8"
+                            max="92"
+                            step="1"
+                            value={proofReveal}
+                            onChange={event => setProofReveal(Number(event.target.value))}
+                            aria-label="Compare raw and auto directed reveal"
+                          />
+                          <div
+                            className="nle-proof-divider"
+                            style={{ left: `${proofReveal}%` }}
+                            aria-hidden="true"
+                          >
+                            <span>↔</span>
+                          </div>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                   <div className="nle-layout-preview-strip">
@@ -9521,164 +9740,211 @@ function MultiCamCombiner({
                       </div>
                     </div>
                   </div>
-                </article>
-
-                <aside className="nle-render-ready-card">
-                  <span className="nle-eyebrow">Render Ready</span>
-                  <strong>{multicamRenderCreditEstimate} cr</strong>
-                  <div
-                    className="nle-render-tier-group is-compact"
-                    aria-label="Cam Combiner render pricing"
-                  >
-                    {MULTICAM_RENDER_TIERS.map(tier => (
-                      <button
-                        key={tier.id}
-                        type="button"
-                        className={`nle-render-tier ${multicamRenderTier === tier.id ? "is-active" : ""}`}
-                        onClick={() => setMulticamRenderTier(tier.id)}
-                      >
-                        <span>{tier.eyebrow}</span>
-                        <strong>{tier.label}</strong>
-                      </button>
-                    ))}
-                  </div>
-                  <div className="nle-render-finishing" aria-label="Final finishing passes">
-                    <label className="nle-render-finish-toggle">
-                      <input
-                        type="checkbox"
-                        checked={multicamBurnCaptions}
-                        onChange={event => setMulticamBurnCaptions(event.target.checked)}
-                      />
-                      <span>
-                        <strong>Burn captions</strong>
-                        <small>Full Whisper + video pass</small>
-                      </span>
-                    </label>
-                    <label className="nle-render-finish-toggle">
-                      <input
-                        type="checkbox"
-                        checked={multicamBrandWatermark}
-                        onChange={event => setMulticamBrandWatermark(event.target.checked)}
-                      />
-                      <span>
-                        <strong>Brand watermark</strong>
-                        <small>Final overlay pass</small>
-                      </span>
-                    </label>
-                    <label className="nle-render-finish-toggle">
-                      <input
-                        type="checkbox"
-                        checked={multicamGenerateThumbnail}
-                        onChange={event => setMulticamGenerateThumbnail(event.target.checked)}
-                      />
-                      <span>
-                        <strong>Thumbnail</strong>
-                        <small>Poster frame only</small>
-                      </span>
-                    </label>
-                  </div>
-                  {hasExternalCleanAudio && readySources.length >= 2 ? (
-                    <div
-                      className={`nle-render-channel-map ${
-                        directorChannelMapConfirmed ? "is-confirmed" : "needs-confirmation"
-                      }`}
-                    >
-                      <strong>
-                        {directorChannelMapConfirmed
-                          ? "Speaker mapping confirmed"
-                          : "Confirm speaker mapping to unlock render"}
-                      </strong>
-                      <span>
-                        Left:{" "}
-                        {getExportSourceLabel(
-                          externalAudioSpeakerChannelsSwapped ? readySources[1] : readySources[0],
-                          externalAudioSpeakerChannelsSwapped ? 1 : 0
-                        )}
-                        {" · "}
-                        Right:{" "}
-                        {getExportSourceLabel(
-                          externalAudioSpeakerChannelsSwapped ? readySources[0] : readySources[1],
-                          externalAudioSpeakerChannelsSwapped ? 0 : 1
-                        )}
-                      </span>
-                      <label>
-                        <input
-                          type="checkbox"
-                          checked={directorChannelMapConfirmed}
-                          onChange={event =>
-                            setConfirmedDirectorChannelMapKey(
-                              event.target.checked ? directorChannelMapKey : ""
-                            )
-                          }
-                        />
-                        <span>I confirm these speakers</span>
-                      </label>
+                  {proofMoments.length ? (
+                    <div className="nle-proof-moments" aria-label="Transformation moments">
+                      {proofMoments.map((moment, index) => (
+                        <button
+                          key={moment.id}
+                          type="button"
+                          className={Math.abs(playhead - moment.time) < 0.75 ? "is-current" : ""}
+                          onClick={() => handleSeek(moment.time)}
+                        >
+                          <span className={`nle-proof-moment-visual is-moment-${index + 1}`}>
+                            <em>{index + 1}</em>
+                          </span>
+                          <span className="nle-proof-moment-copy">
+                            <strong>{moment.label}</strong>
+                            <small>{moment.caption}</small>
+                          </span>
+                          <time>{formatDurationLabel(moment.time)}</time>
+                        </button>
+                      ))}
                     </div>
                   ) : null}
-                  <button
-                    className="nle-btn nle-render-primary-btn"
-                    type="button"
-                    onClick={handleServerExport}
-                    disabled={
-                      isExporting ||
-                      cleanAudioSyncIsRunning ||
-                      syncingCameraId === "external-clean-audio" ||
-                      !canExportProject ||
-                      isSingleSourceWorkflow ||
-                      (hasExternalCleanAudio &&
-                        readySources.length >= 2 &&
-                        !directorChannelMapConfirmed)
-                    }
-                  >
-                    {getMulticamRenderButtonLabel({
-                      mode: cloudRenderMode,
-                      isSyncing:
-                        cleanAudioSyncIsRunning || syncingCameraId === "external-clean-audio",
-                      isPending: serverExportPending,
-                      needsChannelConfirmation:
-                        hasExternalCleanAudio &&
-                        readySources.length >= 2 &&
-                        !directorChannelMapConfirmed,
-                    })}
-                  </button>
-                  <div className="nle-render-proof-list">
-                    <div className={`nle-proof-item ${hasExternalCleanAudio ? "is-done" : ""}`}>
-                      <span>{hasExternalCleanAudio ? "✓" : "1"}</span>
-                      <strong>
-                        {hasExternalCleanAudio
-                          ? "External clean audio locked"
-                          : "Upload external clean audio"}
-                      </strong>
-                    </div>
-                    <div
-                      className={`nle-proof-item ${previewSyncState.tone === "good" ? "is-done" : ""}`}
-                    >
-                      <span>{previewSyncState.tone === "good" ? "✓" : "2"}</span>
-                      <strong>Auto sync proof</strong>
-                    </div>
-                    <div
-                      className={`nle-proof-item ${previewSyncState.tone === "good" ? "is-done" : ""}`}
-                    >
-                      <span>{previewSyncState.tone === "good" ? "✓" : "3"}</span>
-                      <strong>Start · Middle · End verified</strong>
-                    </div>
-                    <div className={`nle-proof-item ${readySources.length >= 2 ? "is-done" : ""}`}>
-                      <span>{readySources.length >= 2 ? "✓" : "4"}</span>
-                      <strong>Reaction overlay optional</strong>
-                    </div>
+                  <div className="nle-proof-receipt" aria-label="Current proof receipt">
+                    {proofReceipt.map((item, index) => (
+                      <div key={item.id} className={`is-${item.id}`}>
+                        <span>{index + 1}</span>
+                        <strong>{item.value}</strong>
+                      </div>
+                    ))}
                   </div>
-                  <div className="nle-studio-credit-note is-simple">
+                </article>
+
+                <aside
+                  className={`nle-render-ready-card nle-proof-render-card ${renderPanelOpen ? "is-open" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="nle-proof-render-summary"
+                    onClick={() => setRenderPanelOpen(current => !current)}
+                    aria-expanded={renderPanelOpen}
+                  >
                     <span>
-                      Balance: {Number(credits?.remaining ?? 0).toFixed(0)} cr. Preview included.
-                      Clean-audio sync is {cleanAudioSyncCreditEstimate} cr when needed.
+                      <small>Ready when you are</small>
+                      <strong>No credits used in preview</strong>
                     </span>
-                    <button
-                      className="nle-mini-paypal-btn"
-                      type="button"
-                      onClick={() => setBillingPanelOpen(true)}
+                    <em>{renderPanelOpen ? "Hide render" : "Review render"}</em>
+                  </button>
+                  <div className="nle-proof-render-details">
+                    <span className="nle-eyebrow">Render Ready</span>
+                    <strong>{multicamRenderCreditEstimate} cr</strong>
+                    <div
+                      className="nle-render-tier-group is-compact"
+                      aria-label="Cam Combiner render pricing"
                     >
-                      Buy credits
+                      {MULTICAM_RENDER_TIERS.map(tier => (
+                        <button
+                          key={tier.id}
+                          type="button"
+                          className={`nle-render-tier ${multicamRenderTier === tier.id ? "is-active" : ""}`}
+                          onClick={() => setMulticamRenderTier(tier.id)}
+                        >
+                          <span>{tier.eyebrow}</span>
+                          <strong>{tier.label}</strong>
+                        </button>
+                      ))}
+                    </div>
+                    <div className="nle-render-finishing" aria-label="Final finishing passes">
+                      <label className="nle-render-finish-toggle">
+                        <input
+                          type="checkbox"
+                          checked={multicamBurnCaptions}
+                          onChange={event => setMulticamBurnCaptions(event.target.checked)}
+                        />
+                        <span>
+                          <strong>Burn captions</strong>
+                          <small>Full Whisper + video pass</small>
+                        </span>
+                      </label>
+                      <label className="nle-render-finish-toggle">
+                        <input
+                          type="checkbox"
+                          checked={multicamBrandWatermark}
+                          onChange={event => setMulticamBrandWatermark(event.target.checked)}
+                        />
+                        <span>
+                          <strong>Brand watermark</strong>
+                          <small>Final overlay pass</small>
+                        </span>
+                      </label>
+                      <label className="nle-render-finish-toggle">
+                        <input
+                          type="checkbox"
+                          checked={multicamGenerateThumbnail}
+                          onChange={event => setMulticamGenerateThumbnail(event.target.checked)}
+                        />
+                        <span>
+                          <strong>Thumbnail</strong>
+                          <small>Poster frame only</small>
+                        </span>
+                      </label>
+                    </div>
+                    {hasExternalCleanAudio && readySources.length >= 2 ? (
+                      <div
+                        className={`nle-render-channel-map ${
+                          directorChannelMapConfirmed ? "is-confirmed" : "needs-confirmation"
+                        }`}
+                      >
+                        <strong>
+                          {directorChannelMapConfirmed
+                            ? "Speaker mapping confirmed"
+                            : "Confirm speaker mapping to unlock render"}
+                        </strong>
+                        <span>
+                          Left:{" "}
+                          {getExportSourceLabel(
+                            externalAudioSpeakerChannelsSwapped ? readySources[1] : readySources[0],
+                            externalAudioSpeakerChannelsSwapped ? 1 : 0
+                          )}
+                          {" · "}
+                          Right:{" "}
+                          {getExportSourceLabel(
+                            externalAudioSpeakerChannelsSwapped ? readySources[0] : readySources[1],
+                            externalAudioSpeakerChannelsSwapped ? 0 : 1
+                          )}
+                        </span>
+                        <label>
+                          <input
+                            type="checkbox"
+                            checked={directorChannelMapConfirmed}
+                            onChange={event =>
+                              setConfirmedDirectorChannelMapKey(
+                                event.target.checked ? directorChannelMapKey : ""
+                              )
+                            }
+                          />
+                          <span>I confirm these speakers</span>
+                        </label>
+                      </div>
+                    ) : null}
+                    <button
+                      className="nle-btn nle-render-primary-btn"
+                      type="button"
+                      onClick={handleServerExport}
+                      disabled={
+                        isExporting ||
+                        cleanAudioSyncIsRunning ||
+                        syncingCameraId === "external-clean-audio" ||
+                        !canExportProject ||
+                        isSingleSourceWorkflow ||
+                        (hasExternalCleanAudio &&
+                          readySources.length >= 2 &&
+                          !directorChannelMapConfirmed)
+                      }
+                    >
+                      {getMulticamRenderButtonLabel({
+                        mode: cloudRenderMode,
+                        isSyncing:
+                          cleanAudioSyncIsRunning || syncingCameraId === "external-clean-audio",
+                        isPending: serverExportPending,
+                        needsChannelConfirmation:
+                          hasExternalCleanAudio &&
+                          readySources.length >= 2 &&
+                          !directorChannelMapConfirmed,
+                      })}
                     </button>
+                    <div className="nle-render-proof-list">
+                      <div className={`nle-proof-item ${hasExternalCleanAudio ? "is-done" : ""}`}>
+                        <span>{hasExternalCleanAudio ? "✓" : "1"}</span>
+                        <strong>
+                          {hasExternalCleanAudio
+                            ? "External clean audio locked"
+                            : "Upload external clean audio"}
+                        </strong>
+                      </div>
+                      <div
+                        className={`nle-proof-item ${previewSyncState.tone === "good" ? "is-done" : ""}`}
+                      >
+                        <span>{previewSyncState.tone === "good" ? "✓" : "2"}</span>
+                        <strong>Auto sync proof</strong>
+                      </div>
+                      <div
+                        className={`nle-proof-item ${previewSyncState.tone === "good" ? "is-done" : ""}`}
+                      >
+                        <span>{previewSyncState.tone === "good" ? "✓" : "3"}</span>
+                        <strong>Start · Middle · End verified</strong>
+                      </div>
+                      <div
+                        className={`nle-proof-item ${readySources.length >= 2 ? "is-done" : ""}`}
+                      >
+                        <span>{readySources.length >= 2 ? "✓" : "4"}</span>
+                        <strong>Reaction overlay optional</strong>
+                      </div>
+                    </div>
+                    <div className="nle-studio-credit-note is-simple">
+                      <span>
+                        Balance: {Number(credits?.remaining ?? 0).toFixed(0)} cr. Preview included.
+                        Clean-audio sync is {cleanAudioSyncCreditEstimate} cr when needed.
+                      </span>
+                      <button
+                        className="nle-mini-paypal-btn"
+                        type="button"
+                        onClick={() => setBillingPanelOpen(true)}
+                      >
+                        Buy credits
+                      </button>
+                    </div>
                   </div>
                 </aside>
               </div>
@@ -9742,6 +10008,7 @@ function MultiCamCombiner({
                             className="nle-thumbnail-video"
                             playsInline
                             muted
+                            preload="metadata"
                           />
                         ) : (
                           <div className="nle-thumbnail-placeholder">Load visual</div>

--- a/frontend/src/components/__tests__/MultiCamCombiner.proofMode.test.js
+++ b/frontend/src/components/__tests__/MultiCamCombiner.proofMode.test.js
@@ -1,0 +1,125 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import MultiCamCombiner, {
+  buildCamCombinerProofMoments,
+  getCamCombinerProofReceipt,
+} from "../MultiCamCombiner";
+
+jest.mock("firebase/auth", () => ({
+  getAuth: () => ({ currentUser: null }),
+}));
+
+jest.mock("firebase/storage", () => ({
+  getStorage: jest.fn(),
+  ref: jest.fn(),
+  uploadBytesResumable: jest.fn(),
+  getDownloadURL: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  error: jest.fn(),
+  success: jest.fn(),
+}));
+
+jest.mock("../../hooks/useSubscription", () => ({
+  useSubscription: () => ({
+    canUseFeature: () => true,
+    credits: { remaining: 999 },
+  }),
+}));
+
+jest.mock("../../hooks/useCinematicEffects", () => () => ({
+  fx: { zoom: 1 },
+  showPanel: false,
+  setShowPanel: jest.fn(),
+  applyPreset: jest.fn(),
+  updateFx: jest.fn(),
+  resetFx: jest.fn(),
+  mediaStyle: {},
+  edgeBlurStyle: null,
+  vignetteStyle: null,
+  overlayStyle: null,
+  grainStyle: null,
+  letterboxStyle: null,
+  fadeStyle: null,
+  hasEffects: false,
+  attachVideo: jest.fn(),
+}));
+
+describe("MultiCamCombiner Proof Mode helpers", () => {
+  it("opens in Compare and keeps paid render controls behind an explicit review action", () => {
+    render(
+      <MultiCamCombiner
+        primaryFile={{
+          url: "https://cdn.example.com/camera-one.jpg",
+          isRemote: true,
+          name: "camera-one.jpg",
+          type: "image/jpeg",
+        }}
+        onCancel={jest.fn()}
+        onComplete={jest.fn()}
+        onStatusChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Proof Mode")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Compare" })).toHaveAttribute("aria-pressed", "true");
+
+    const renderSummary = screen.getByRole("button", { name: /ready when you are/i });
+    expect(renderSummary).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(renderSummary);
+    expect(renderSummary).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+    expect(screen.getByRole("button", { name: "Raw" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("uses real switch timestamps for the transformation moment rail", () => {
+    const moments = buildCamCombinerProofMoments(
+      [
+        { startTime: 0, cameraId: "cam-1" },
+        { startTime: 8, cameraId: "cam-2" },
+        { startTime: 22, cameraId: "cam-1" },
+        { startTime: 44, cameraId: "cam-2" },
+      ],
+      60
+    );
+
+    expect(moments).toEqual([
+      expect.objectContaining({ id: "speaker-cut", label: "Speaker cut", time: 8 }),
+      expect.objectContaining({ id: "reaction-caught", label: "Reaction caught", time: 22 }),
+      expect.objectContaining({ id: "shared-moment", label: "Shared moment", time: 44 }),
+    ]);
+  });
+
+  it("falls back to useful points in the timeline and never exceeds its duration", () => {
+    expect(buildCamCombinerProofMoments([], 100).map(moment => moment.time)).toEqual([24, 52, 76]);
+    expect(buildCamCombinerProofMoments([{ startTime: 0 }, { startTime: 999 }], 30)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ time: 30 })])
+    );
+    expect(buildCamCombinerProofMoments([], 0)).toEqual([]);
+  });
+
+  it("reports only the current cut, reaction, audio, and sync state", () => {
+    expect(
+      getCamCombinerProofReceipt({
+        switches: [{ startTime: 0 }, { startTime: 8 }, { startTime: 22 }],
+        reactionOverlayEnabled: true,
+        hasExternalCleanAudio: true,
+        syncTone: "good",
+      })
+    ).toEqual([
+      { id: "cuts", value: "3 camera cuts" },
+      { id: "reactions", value: "Smart reactions" },
+      { id: "audio", value: "Clean audio" },
+      { id: "sync", value: "Sync locked" },
+    ]);
+
+    expect(getCamCombinerProofReceipt()).toEqual([
+      { id: "cuts", value: "0 camera cuts" },
+      { id: "reactions", value: "Reactions off" },
+      { id: "audio", value: "Camera audio" },
+      { id: "sync", value: "Sync pending" },
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- adds the Cam Combiner Proof Mode with Raw, Auto Directed, and synchronized Compare views
- adds real transformation moments and an honest proof receipt driven by current cut, reaction, audio, and sync state
- keeps paid render controls collapsed until explicitly reviewed
- fixes recovered camera previews that could appear ready while Program Output remained blank
- preserves the branch's existing Viral Clip Studio and render-pipeline improvements

## Why

Creators need to see the transformation before spending credits. The new proof-first hierarchy makes the before/after result obvious while keeping the existing render, sync, credit, and worker contracts intact.

## Validation

- 5 focused test suites passed
- 40/40 tests passed
- production frontend build compiled successfully
- Prettier and diff checks passed

No render job or Cloud Run deployment was started during validation.